### PR TITLE
changing radical log directory from new param

### DIFF
--- a/deepdrivemd/config.py
+++ b/deepdrivemd/config.py
@@ -204,6 +204,7 @@ class ExperimentConfig(BaseSettings):
     gpus_per_node: int
     hardware_threads_per_cpu: int
     experiment_directory: Path
+    radical_session_directory: Path
     node_local_path: Optional[Path]
     molecular_dynamics_stage: MolecularDynamicsStageConfig
     aggregation_stage: AggregationStageConfig
@@ -233,6 +234,7 @@ def generate_sample_config():
         gpus_per_node=6,
         max_iteration=4,
         experiment_directory="/path/to/experiment",
+        radical_session_directory="/path/to/radical",
         node_local_path=None,
         molecular_dynamics_stage=MolecularDynamicsStageConfig(),
         aggregation_stage=AggregationStageConfig(),

--- a/deepdrivemd/deepdrivemd.py
+++ b/deepdrivemd/deepdrivemd.py
@@ -251,10 +251,11 @@ if __name__ == "__main__":
             port=int(os.environ["RMQ_PORT"]),
             username=os.environ["RMQ_USERNAME"],
             password=os.environ["RMQ_PASSWORD"],
+            config={'base_path':cfg.radical_session_directory}
         )
     except KeyError:
         raise ValueError(
-            "Invalid RMQ environment. Please see README.md for configuring environment."
+            "Invalid RADICAL configurations, e.g. RMQ. Please see README.md for configuring environment."
         )
 
     # Calculate total number of nodes required. Assumes 1 MD job per GPU

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ packages= find:
 install_requires = 
     pyyaml
     pydantic
-    radical.entk @ git+https://github.com/radical-cybertools/radical.entk@feature/change_base_path
+    radical.entk @ git+https://github.com/radical-cybertools/radical.entk@devel
     MDAnalysis
     numpy
     h5py==2.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ packages= find:
 install_requires = 
     pyyaml
     pydantic
-    radical.entk
+    radical.entk @ git+https://github.com/radical-cybertools/radical.entk@feature/change_base_path
     MDAnalysis
     numpy
     h5py==2.10.0


### PR DESCRIPTION
Once this feature is supported in the latest radical.entk version, we can merge support.

We may want to set the default `radical_session_directory` to be inside the `experiment_directory` to encapsulate the DDMD output to a single place. The current default is to use the current working directory.